### PR TITLE
Added test credentials action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.1.3
+
+- Added a new action `test_credentials` that tests if the credentials in the config are valid.
+  Contributed by Nick Maludy (Encore Technologies)
+
 ## 0.1.2
 
 - Added base action class with common code. Removed duplicate code from other actions

--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ You need to set configuration when you run following Action. These are the confi
 | zabbix.host_delete                    | Delete a Zabbix Host |
 | zabbix.maintenance_create_or_update   | Create or update Zabbix Maintenance Window |
 | zabbix.maintenance_delete             | Delete Zabbix Maintenance Window |
+| zabbix.test_credentials               | Tests if it credentials in the config are valid |

--- a/actions/test_credentials.py
+++ b/actions/test_credentials.py
@@ -1,0 +1,26 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.actions import ZabbixBaseAction
+
+
+class TestCredentials(ZabbixBaseAction):
+
+    def run(self, host=None):
+        """ Attempt to login to the Zabbix server given the credentials in the
+        config
+        """
+        self.connect()
+        return True

--- a/actions/test_credentials.yaml
+++ b/actions/test_credentials.yaml
@@ -1,0 +1,7 @@
+---
+name: test_credentials
+pack: zabbix
+runner_type: python-script
+description: Attempts to login to Zabbix given the credentials in the config
+enabled: true
+entry_point: test_credentials.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: StackStorm pack that contains Zabbix integrations
 keywords:
   - zabbix
   - monitoring
-version: 0.1.2
+version: 0.1.3
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 py-zabbix==1.1.3
 st2client
 pytz
+tzlocal

--- a/tests/test_test_credentials.py
+++ b/tests/test_test_credentials.py
@@ -1,0 +1,24 @@
+import mock
+
+from zabbix_base_action_test_case import ZabbixBaseActionTestCase
+from test_credentials import TestCredentials
+
+from pyzabbix.api import ZabbixAPIException
+
+
+class TestCredentialsTestCase(ZabbixBaseActionTestCase):
+    __test__ = True
+    action_cls = TestCredentials
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        result = action.run()
+        self.assertEqual(result, True)
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_connection_error(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.side_effect = ZabbixAPIException('login error')
+        with self.assertRaises(ZabbixAPIException):
+            action.run()


### PR DESCRIPTION
Added an action that tests if the credentials stored in the config are valid or not.

Makes a simple login connection the exits. 

Action returns success when creds are good and fails when creds are bad.

Upon failure an exception is thrown and available in stderr with more details from the API.