### PR TITLE
New action - host_delete_by_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.1.4
+
+- Added a new action `host_get_status` that retrieves the status of a host in Zabbix.
+  Contributed by Brad Bishop (Encore Technologies)
+
 ## 0.1.3
 
 - Added a new action `test_credentials` that tests if the credentials in the config are valid.

--- a/actions/host_get_multiple_ids.py
+++ b/actions/host_get_multiple_ids.py
@@ -29,12 +29,12 @@ class ZabbixGetMultipleHostID(ZabbixBaseAction):
             raise ZabbixAPIException(("There was a problem searching for the host: "
                                     "{0}".format(e)))
 
-        zabbit_hosts_return = []
+        zabbix_hosts_return = []
         if len(zabbix_hosts) > 0:
             for host in zabbix_hosts:
-                zabbit_hosts_return.append(host['hostid'])
+                zabbix_hosts_return.append(host['hostid'])
 
-        return zabbit_hosts_return
+        return zabbix_hosts_return
 
     def run(self, host=None):
         """ Gets the IDs of the Zabbix host given the Hostname or FQDN

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: StackStorm pack that contains Zabbix integrations
 keywords:
   - zabbix
   - monitoring
-version: 0.1.3
+version: 0.1.4
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com


### PR DESCRIPTION
To go along with our last PR.

We also need to delete the duplicate host. The existing `host_delete` action only allowed deleting by host name. In the case of duplicates, this failed because there could be multiple hosts with the same name. 

A new action was created `host_delete_by_id` that requires the user to input a `host_id` and we explicitly delete that host.