### PR TITLE
Fixed configuration of 'zabbix.event_handler' trigger to be compatible with StackStorm validator

### DIFF
--- a/triggers/event_handler.yaml
+++ b/triggers/event_handler.yaml
@@ -13,4 +13,5 @@ payload_schema:
       type: string
     extra_args:
       type: array
-      items: string
+      items:
+        type: string


### PR DESCRIPTION
This fixes #19. This is because of the wrong setting of trigger configuration of `zabbix.event_handler`.

For an array property, `item` has value of dict type.
(c.f. https://github.com/StackStorm/st2/blob/master/st2common/st2common/util/schema/__init__.py#L264)

But this pack sets string value to it. This seems to cause runtime problem as mentioned in #19.

This is a check result of this patch.
<img width="514" alt="2018-10-30 22 26 39" src="https://user-images.githubusercontent.com/469934/47723147-40322280-dc97-11e8-9a11-25cf91c08874.png">

To check it automatically, I'll make an integration test suite such like https://github.com/StackStorm-Exchange/stackstorm-zabbix/issues/18#issuecomment-432218372 with another PR.
