### PR TITLE
Adding new action - host_get_inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.8
+
+### Added
+
+- New Action: `host_get_inventory` - Get the inventory of one or more Zabbix Hosts
+
 ## 0.1.7
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can specify additional parameters and you can handle them from the payload o
 
 ### Deploy the AlertScript
 
-The script `st2_dispatcher.py` sends Zabbix events to the StackStorm server. Copy this script to the directory which Zabbix MediaType refers to. The directory is specified by the parameter of `AlertScriptsPath` in the Zabbix configuration file on the node which zabbix was installed.
+The script `st2_dispatch.py` sends Zabbix events to the StackStorm server. Copy this script to the directory which Zabbix MediaType refers to. The directory is specified by the parameter of `AlertScriptsPath` in the Zabbix configuration file on the node which zabbix was installed.
 ```shell
 $ grep 'AlertScriptsPath' /etc/zabbix/zabbix_server.conf
 ### Option: AlertScriptsPath
@@ -68,7 +68,7 @@ $ grep 'AlertScriptsPath' /etc/zabbix/zabbix_server.conf
 AlertScriptsPath=/usr/lib/zabbix/alertscripts
 ```
 
-This pack requires you to deploy this `st2_dispatcher.py` in its directory (and setup executional environment if necessary) on the Zabbix installed node. Set it up depending on your environment as below:
+This pack requires you to deploy this `st2_dispatch.py` in its directory (and setup executional environment if necessary) on the Zabbix installed node. Set it up depending on your environment as below:
 
 #### Case: single node
 
@@ -76,7 +76,7 @@ Both of StackStorm and Zabbix are installed on the same system:
 
 <img src="./images/description_alertscript1.png" width="350">
 
-This case is quite simple. All you have to do is copy `st2_dispatcher.py` to the directory which AlertScripts should be located.
+This case is quite simple. All you have to do is copy `st2_dispatch.py` to the directory which AlertScripts should be located.
 ```shell
 $ sudo cp /opt/stackstorm/packs/zabbix/tools/scripts/st2_dispatch.py /usr/lib/zabbix/alertscripts/
 ```
@@ -87,7 +87,7 @@ Zabbix and StackStorm are installed on separate systems, with IP connectivity be
 
 <img src="./images/description_alertscript2.png" width="350">
 
-In this case, you have to do two things (deploying and making executional environment) to set it up. First copy `st2_dispatcher.py` from the StackStorm server to the AlertScript directory on the Zabbix node.
+In this case, you have to do two things (deploying and making executional environment) to set it up. First copy `st2_dispatch.py` from the StackStorm server to the AlertScript directory on the Zabbix node.
 
 ```shell
 ubuntu@zabbix-node:~$ scp st2-node:/opt/stackstorm/packs/zabbix/tools/scripts/st2_dispatch.py ./

--- a/actions/host_get_inventory.py
+++ b/actions/host_get_inventory.py
@@ -24,15 +24,6 @@ class HostGetStatus(ZabbixBaseAction):
         self.connect()
 
         # Find inventory by host ids
-        items = self.client.item.get(hostids=host_ids)
+        inventory = self.client.host.get(hostids=host_ids, selectInventory='extend', output=['hostid', 'inventory'])
 
-        hosts = []
-        for _id in host_ids:
-            host = {"id": _id, "inventory": []}
-            for i in items:
-                if _id == i['hostid'] and i['inventory_link'] != '0':
-                    item = {"name": i['name'], "value": i['lastvalue']}
-                    host['inventory'].append(item)
-            hosts.append(host)
-
-        return hosts
+        return inventory

--- a/actions/host_get_inventory.py
+++ b/actions/host_get_inventory.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from lib.actions import ZabbixBaseAction
+from pyzabbix.api import ZabbixAPIException
 
 
 class HostGetStatus(ZabbixBaseAction):
@@ -24,7 +25,11 @@ class HostGetStatus(ZabbixBaseAction):
         self.connect()
 
         # Find inventory by host ids
-        inventory = self.client.host.get(
-            hostids=host_ids, selectInventory='extend', output=['hostid', 'inventory'])
+        try:
+            inventory = self.client.host.get(
+                hostids=host_ids, selectInventory='extend', output=['hostid', 'inventory'])
+        except ZabbixAPIException as e:
+            raise ZabbixAPIException(("There was a problem searching for the host: "
+                                      "{0}".format(e)))
 
         return inventory

--- a/actions/host_get_inventory.py
+++ b/actions/host_get_inventory.py
@@ -1,0 +1,38 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.actions import ZabbixBaseAction
+
+
+class HostGetStatus(ZabbixBaseAction):
+
+    def run(self, host_ids=None):
+        """ Gets the inventory of one or more Zabbix Hosts.
+        """
+        self.connect()
+
+        # Find inventory by host ids
+        items = self.client.item.get(hostids=host_ids)
+
+        hosts = []
+        for _id in host_ids:
+            host = {"id": _id, "inventory": []}
+            for i in items:
+                if _id == i['hostid'] and i['inventory_link'] != '0':
+                    item = {"name": i['name'], "value": i['lastvalue']}
+                    host['inventory'].append(item)
+            hosts.append(host)
+
+        return hosts

--- a/actions/host_get_inventory.py
+++ b/actions/host_get_inventory.py
@@ -17,7 +17,7 @@ from lib.actions import ZabbixBaseAction
 from pyzabbix.api import ZabbixAPIException
 
 
-class HostGetStatus(ZabbixBaseAction):
+class HostGetInventory(ZabbixBaseAction):
 
     def run(self, host_ids=None):
         """ Gets the inventory of one or more Zabbix Hosts.

--- a/actions/host_get_inventory.py
+++ b/actions/host_get_inventory.py
@@ -24,6 +24,7 @@ class HostGetStatus(ZabbixBaseAction):
         self.connect()
 
         # Find inventory by host ids
-        inventory = self.client.host.get(hostids=host_ids, selectInventory='extend', output=['hostid', 'inventory'])
+        inventory = self.client.host.get(
+            hostids=host_ids, selectInventory='extend', output=['hostid', 'inventory'])
 
         return inventory

--- a/actions/host_get_inventory.yaml
+++ b/actions/host_get_inventory.yaml
@@ -1,0 +1,12 @@
+---
+name: host_get_inventory
+pack: zabbix
+runner_type: python-script
+description: Get the inventory of one or more Zabbix Hosts
+enabled: true
+entry_point: host_get_inventory.py
+parameters:
+    host_ids:
+        type: array
+        description: "List of Host IDs to find inventory items for"
+        required: True

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: StackStorm pack that contains Zabbix integrations
 keywords:
   - zabbix
   - monitoring
-version: 0.1.7
+version: 0.1.8
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com

--- a/tests/test_host_get_inventory.py
+++ b/tests/test_host_get_inventory.py
@@ -5,6 +5,7 @@ from host_get_inventory import HostGetInventory
 
 from urllib2 import URLError
 
+
 class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
     __test__ = True
     action_cls = HostGetInventory
@@ -32,7 +33,9 @@ class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
 
         result = action.run(**test_dict)
         mock_client.host.get.assert_called_with(
-            hostids=test_dict['host_ids'], selectInventory='extend', output=['hostid', 'inventory'])
+            hostids=test_dict['host_ids'],
+            selectInventory='extend',
+            output=['hostid', 'inventory'])
         self.assertEqual(result, inventory_list)
 
     @mock.patch('lib.actions.ZabbixAPI')
@@ -65,7 +68,9 @@ class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
 
         result = action.run(**test_dict)
         mock_client.host.get.assert_called_with(
-            hostids=test_dict['host_ids'], selectInventory='extend', output=['hostid', 'inventory'])
+            hostids=test_dict['host_ids'],
+            selectInventory='extend',
+            output=['hostid', 'inventory'])
         self.assertEqual(result, expected_return)
 
     @mock.patch('lib.actions.ZabbixAPI')
@@ -74,10 +79,10 @@ class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
         action = self.get_action_instance(self.full_config)
         mock_connect.return_vaue = "connect return"
         test_dict = {'host_ids': ["12345", "98765"]}
-        inventory_list = [{'hostid': "12345", 'inventory': 
-                          {'serialno_a': "abcd1234", 'name': "test"}},
-                          {'hostid': "98765", 'inventory': 
-                          {'serialno_a': "efgh5678", 'name': "test2"}}]
+        inventory_list = [{'hostid': "12345", 'inventory':
+                           {'serialno_a': "abcd1234", 'name': "test"}},
+                          {'hostid': "98765", 'inventory':
+                           {'serialno_a': "efgh5678", 'name': "test2"}}]
         action.connect = mock_connect
         mock_client.host.get.return_value = inventory_list
         action.client = mock_client
@@ -88,5 +93,7 @@ class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
 
         result = action.run(**test_dict)
         mock_client.host.get.assert_called_with(
-            hostids=test_dict['host_ids'], selectInventory='extend', output=['hostid', 'inventory'])
+            hostids=test_dict['host_ids'],
+            electInventory='extend',
+            output=['hostid', 'inventory'])
         self.assertEqual(result, expected_return)

--- a/tests/test_host_get_inventory.py
+++ b/tests/test_host_get_inventory.py
@@ -4,8 +4,6 @@ from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from host_get_inventory import HostGetInventory
 
 from urllib2 import URLError
-from pyzabbix.api import ZabbixAPIException
-
 
 class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
     __test__ = True
@@ -76,8 +74,10 @@ class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
         action = self.get_action_instance(self.full_config)
         mock_connect.return_vaue = "connect return"
         test_dict = {'host_ids': ["12345", "98765"]}
-        inventory_list = [{'hostid': "12345", 'inventory': {'serialno_a': "abcd1234", 'name': "test"}},
-                          {'hostid': "98765", 'inventory': {'serialno_a': "efgh5678", 'name': "test2"}}]
+        inventory_list = [{'hostid': "12345", 'inventory': 
+                          {'serialno_a': "abcd1234", 'name': "test"}},
+                          {'hostid': "98765", 'inventory': 
+                          {'serialno_a': "efgh5678", 'name': "test2"}}]
         action.connect = mock_connect
         mock_client.host.get.return_value = inventory_list
         action.client = mock_client

--- a/tests/test_host_get_inventory.py
+++ b/tests/test_host_get_inventory.py
@@ -94,6 +94,6 @@ class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
         result = action.run(**test_dict)
         mock_client.host.get.assert_called_with(
             hostids=test_dict['host_ids'],
-            electInventory='extend',
+            selectInventory='extend',
             output=['hostid', 'inventory'])
         self.assertEqual(result, expected_return)

--- a/tests/test_host_get_inventory.py
+++ b/tests/test_host_get_inventory.py
@@ -1,0 +1,92 @@
+import mock
+
+from zabbix_base_action_test_case import ZabbixBaseActionTestCase
+from host_get_inventory import HostGetInventory
+
+from urllib2 import URLError
+from pyzabbix.api import ZabbixAPIException
+
+
+class HostGetInventoryTestCase(ZabbixBaseActionTestCase):
+    __test__ = True
+    action_cls = HostGetInventory
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_connection_error(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.side_effect = URLError('connection error')
+        test_dict = {'host_ids': ["12345"]}
+
+        with self.assertRaises(URLError):
+            action.run(**test_dict)
+
+    @mock.patch('lib.actions.ZabbixAPI')
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_host_error(self, mock_connect, mock_client):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host_ids': ["12345"]}
+        inventory_list = [{'hostid': "12345", 'inventory': {
+            'serialno_a': "abcd1234", 'name': "test"}}]
+        action.connect = mock_connect
+        mock_client.host.get.return_value = inventory_list
+        action.client = mock_client
+
+        result = action.run(**test_dict)
+        mock_client.host.get.assert_called_with(
+            hostids=test_dict['host_ids'], selectInventory='extend', output=['hostid', 'inventory'])
+        self.assertEqual(result, inventory_list)
+
+    @mock.patch('lib.actions.ZabbixAPI')
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_none(self, mock_connect, mock_client):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host_ids': ["12345"]}
+        inventory_list = []
+        action.connect = mock_connect
+        mock_client.host.get.return_value = inventory_list
+        action.client = mock_client
+
+        result = action.run(**test_dict)
+        self.assertEqual(result, [])
+
+    @mock.patch('lib.actions.ZabbixAPI')
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_single(self, mock_connect, mock_client):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host_ids': ["12345"]}
+        inventory_list = [{'hostid': "12345", 'inventory': {
+            'serialno_a': "abcd1234", 'name': "test"}}]
+        action.connect = mock_connect
+        mock_client.host.get.return_value = inventory_list
+        action.client = mock_client
+        expected_return = [{'hostid': inventory_list[0][
+            'hostid'], 'inventory': inventory_list[0]['inventory']}]
+
+        result = action.run(**test_dict)
+        mock_client.host.get.assert_called_with(
+            hostids=test_dict['host_ids'], selectInventory='extend', output=['hostid', 'inventory'])
+        self.assertEqual(result, expected_return)
+
+    @mock.patch('lib.actions.ZabbixAPI')
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_multiple(self, mock_connect, mock_client):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host_ids': ["12345", "98765"]}
+        inventory_list = [{'hostid': "12345", 'inventory': {'serialno_a': "abcd1234", 'name': "test"}},
+                          {'hostid': "98765", 'inventory': {'serialno_a': "efgh5678", 'name': "test2"}}]
+        action.connect = mock_connect
+        mock_client.host.get.return_value = inventory_list
+        action.client = mock_client
+        expected_return = [{'hostid': inventory_list[0]['hostid'],
+                            'inventory': inventory_list[0]['inventory']},
+                           {'hostid': inventory_list[1]['hostid'],
+                            'inventory': inventory_list[1]['inventory']}]
+
+        result = action.run(**test_dict)
+        mock_client.host.get.assert_called_with(
+            hostids=test_dict['host_ids'], selectInventory='extend', output=['hostid', 'inventory'])
+        self.assertEqual(result, expected_return)


### PR DESCRIPTION
This new action will query the zabbix api for the inventory belonging to a host by `host_id`.

Returns data found in this table - https://www.zabbix.com/documentation/3.4/manual/api/reference/host/object#host_inventory

good for use with external (to zabbix) cmdb/asset inventory