### PR TITLE
Fixed a problem of the script to register st2 configuration to Zabbix and added an integration test for it.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
             sudo pip install pip --upgrade
             sudo pip install -r requirements.txt
             bundle install
-            bundle exec rspec
+            bundle exec rspec --format documentation
 
 executors:
   zabbix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,7 @@
 version: 2.1
 
-jobs:
+commands:
   integration_test_with_zabbix:
-    parameters:
-      zabbix_image_tag:
-        type: string
-
-    docker:
-      - image: circleci/ruby:2.4-jessie
-      - image: mysql:5.7
-        environment:
-          MYSQL_DATABASE: zabbix
-          MYSQL_USER: zabbix
-          MYSQL_PASSWORD: zabbix
-          MYSQL_ROOT_PASSWORD: passwd
-
-      - image: "zabbix/zabbix-server-mysql:<< parameters.zabbix_image_tag >>"
-        environment:
-          DB_SERVER_HOST: 127.0.0.1
-          MYSQL_ROOT_PASSWORD: passwd
-
-      - image: "zabbix/zabbix-web-nginx-mysql:<< parameters.zabbix_image_tag >>"
-        environment:
-          DB_SERVER_HOST: 127.0.0.1
-          MYSQL_ROOT_PASSWORD: passwd
-
-    working_directory: ~/repo
     steps:
       - checkout
       - run:
@@ -37,6 +13,48 @@ jobs:
             sudo pip install -r requirements.txt
             bundle install
             bundle exec rspec
+
+executors:
+  zabbix:
+    parameters:
+      tag:
+        type: string
+        default: latest
+    docker:
+      - image: circleci/ruby:2.4-jessie
+      - image: mysql:5.7
+        environment:
+          MYSQL_DATABASE: zabbix
+          MYSQL_USER: zabbix
+          MYSQL_PASSWORD: zabbix
+          MYSQL_ROOT_PASSWORD: passwd
+
+      - image: "zabbix/zabbix-server-mysql:<< parameters.tag >>"
+        environment:
+          DB_SERVER_HOST: 127.0.0.1
+          MYSQL_ROOT_PASSWORD: passwd
+
+      - image: "zabbix/zabbix-web-nginx-mysql:<< parameters.tag >>"
+        environment:
+          DB_SERVER_HOST: 127.0.0.1
+          MYSQL_ROOT_PASSWORD: passwd
+
+jobs:
+  integration_test_with_zabbix_32:
+    executor:
+      name: zabbix
+      tag: ubuntu-3.2-latest
+    working_directory: ~/repo
+    steps:
+      - integration_test_with_zabbix
+
+  integration_test_with_zabbix_40:
+    executor:
+      name: zabbix
+      tag: ubuntu-4.0-latest
+    working_directory: ~/repo
+    steps:
+      - integration_test_with_zabbix
 
   build_and_test_python27:
     docker:
@@ -152,10 +170,8 @@ workflows:
   # Workflow which runs on each push
   build_test_deploy_on_push:
     jobs:
-      - integration_test_with_zabbix:
-          zabbix_image_tag: ubuntu-3.2-latest
-      - integration_test_with_zabbix:
-          zabbix_image_tag: ubuntu-4.0-latest
+      - integration_test_with_zabbix_32
+      - integration_test_with_zabbix_40
       - build_and_test_python27
       - build_and_test_python36
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,43 @@
-version: 2
+version: 2.1
 
 jobs:
+  integration_test_with_zabbix:
+    parameters:
+      zabbix_image_tag:
+        type: string
+
+    docker:
+      - image: circleci/ruby:2.4-jessie
+      - image: mysql:5.7
+        environment:
+          MYSQL_DATABASE: zabbix
+          MYSQL_USER: zabbix
+          MYSQL_PASSWORD: zabbix
+          MYSQL_ROOT_PASSWORD: passwd
+
+      - image: "zabbix/zabbix-server-mysql:<< parameters.zabbix_image_tag >>"
+        environment:
+          DB_SERVER_HOST: 127.0.0.1
+          MYSQL_ROOT_PASSWORD: passwd
+
+      - image: "zabbix/zabbix-web-nginx-mysql:<< parameters.zabbix_image_tag >>"
+        environment:
+          DB_SERVER_HOST: 127.0.0.1
+          MYSQL_ROOT_PASSWORD: passwd
+
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Execute integration test with Zabbix
+          command: |
+            set -x
+            sudo apt -y install python-pip
+            sudo pip install pip --upgrade
+            sudo pip install -r requirements.txt
+            bundle install
+            bundle exec rspec
+
   build_and_test_python27:
     docker:
       - image: circleci/python:2.7
@@ -115,6 +152,10 @@ workflows:
   # Workflow which runs on each push
   build_test_deploy_on_push:
     jobs:
+      - integration_test_with_zabbix:
+          zabbix_image_tag: ubuntu-3.2-latest
+      - integration_test_with_zabbix:
+          zabbix_image_tag: ubuntu-4.0-latest
       - build_and_test_python27
       - build_and_test_python36
       - deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,10 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Auto generated files by Bundler and Rspec
+Gemfile.lock
+.rspec
+
+# temporary files of Vim
+.*.sw*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.10
+
+- The script that registers st2's configuration to Zabbix would be compatible with Zabbix v4.0.
+- An integration test for `register_st2_config_to_zabbix.py` with different version of Zabbix was added.
+- A configuration file of docker-compose was added for running integration test in local machine.
+
 ## 0.1.9
 
 - Version bump to fix tagging issue. No code change

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem 'docker-api'
+gem 'rake'
+gem 'serverspec'
+gem 'zbxapi'

--- a/README.md
+++ b/README.md
@@ -198,3 +198,50 @@ You need to set configure the Zabbix pack before running actions:
 | zabbix.maintenance_create_or_update   | Create or update Zabbix Maintenance Window |
 | zabbix.maintenance_delete             | Delete Zabbix Maintenance Window |
 | zabbix.test_credentials               | Tests if it credentials in the config are valid |
+
+# Running Test
+## Unit Test
+You can run unit tests by `st2-run-pack-tests` command that is provided by [StackStorm](https://github.com/StackStorm/st2) as below.
+
+```
+$ git clone git@github.com:StackStorm-Exchange/stackstorm-zabbix.git
+$ git clone git@github.com:StackStorm/st2.git
+$ st2/st2common/bin/st2-run-pack-tests -x -p ~/stackstorm-zabbix/
+```
+
+For more detail on this topic, please see the [official document page](https://docs.stackstorm.com/development/pack_testing.html).
+
+## Integration Test
+You can also run test with actual Zabbix server and Zabbix API server in your local environment using Zabbix Docker Images ([zabbix-server-mysql](https://hub.docker.com/r/zabbix/zabbix-server-mysql) and [zabbix-web-nginx-mysql](https://hub.docker.com/r/zabbix/zabbix-web-nginx-mysql)) and [Serverspec](https://serverspec.org/). This describes how to run the integration tests.
+
+### 0. Preparing for running RSpec tests
+For the first time in your environment to run this test, it's necessary to make an environment for RSpec as below.
+```
+$ cd stackstorm-zabbix
+$ gem install bundler
+$ bundle install
+```
+To make this environment by this procedure, you have to install Ruby (`v2.4` or later).
+
+### 1. Running Docker images for Zabbix
+You can run Zabbix services (Zabbix server and Zabbix Web API) for the integration test so quickly using Docker. To run these containers you should specify the environment variable of TAG which means Zabbix version of container to start.
+This command starts Docker containers of both Zabbix services which are `v3.2`.
+
+```
+$ TAG=ubuntu-3.2-latest docker-compose up -d
+```
+
+When you want to start Zabbix v4.0 containers, you can do it like this.
+
+```
+$ TAG=ubuntu-4.0-latest docker-compose up -d
+```
+
+All values you could specify in this variable is [here](https://hub.docker.com/r/zabbix/zabbix-server-mysql/tags).
+
+### 2. Running tests
+Starting procedure to run the test is also simple, all you have to do is executing rspec as below.
+
+```
+$ bundle exec rspec
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,27 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+namespace :spec do
+  targets = []
+  Dir.glob('./spec/*').each do |dir|
+    next unless File.directory?(dir)
+    target = File.basename(dir)
+    target = "_#{target}" if target == "default"
+    targets << target
+  end
+
+  task :all     => targets
+  task :default => :all
+
+  targets.each do |target|
+    original_target = target == "_default" ? target[1..-1] : target
+    desc "Run serverspec tests to #{original_target}"
+    RSpec::Core::RakeTask.new(target.to_sym) do |t|
+      ENV['TARGET_HOST'] = original_target
+      t.pattern = "spec/#{original_target}/*_spec.rb"
+    end
+  end
+end

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,35 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: zabbix
+      MYSQL_USER: zabbix
+      MYSQL_PASSWORD: zabbix
+      MYSQL_ROOT_PASSWORD: passwd
+
+  zabbix-server:
+    image: zabbix/zabbix-server-mysql:${TAG}
+    environment:
+      DB_SERVER_HOST: mysql
+      MYSQL_ROOT_PASSWORD: passwd
+    depends_on:
+      - mysql
+    volumes:
+      - ./tools/scripts/st2_dispatch.py:/usr/lib/zabbix/alertscripts/st2_dispatch.py
+    ports:
+      - "10051:10051"
+
+  zabbix-web:
+    image: zabbix/zabbix-web-nginx-mysql:${TAG}
+    restart: always
+    environment:
+      DB_SERVER_HOST: mysql
+      MYSQL_ROOT_PASSWORD: passwd
+    ports:
+      - 3033:80
+    depends_on:
+      - mysql
+      - zabbix-server

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: Zabbix Monitoring System
 keywords:
   - zabbix
   - monitoring
-version: 0.1.9
+version: 0.1.10
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com

--- a/spec/localhost/tools_register_config_for_st2_spec.rb
+++ b/spec/localhost/tools_register_config_for_st2_spec.rb
@@ -1,0 +1,52 @@
+require 'zbxapi'
+require 'spec_helper'
+
+ZABBIX_USER = ENV['ZABBIX_USER'] || 'admin'
+ZABBIX_SENDTO = ENV['ZABBIX_SENDTO'] || 'admin'
+ZABBIX_PASSWORD = ENV['ZABBIX_PASSWORD'] || 'zabbix'
+ZABBIX_API_ENDPOINT = ENV['ZABBIX_API'] || 'http://localhost/'
+
+describe 'Tests for registering Zabbix for StackStorm' do
+  before(:all) do
+    @client = ZabbixAPI.new(ZABBIX_API_ENDPOINT)
+
+    expect(try_to_login).not_to be_a(RuntimeError)
+  end
+
+  # run script to register configurations for StackStorm to the Zabbix
+  describe command("tools/register_st2_config_to_zabbix.py " \
+                   "-u #{ ZABBIX_USER } " \
+                   "-s #{ ZABBIX_SENDTO } " \
+                   "-p #{ ZABBIX_PASSWORD } " \
+                   "-z #{ ZABBIX_API_ENDPOINT }") do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) do 
+      should match /^Success to register the configurations for StackStorm to the Zabbix Server./
+    end
+
+    describe 'Check each configurations are actually set in the Zabbix' do
+      it 'MediaType configuration is set' do
+        expect(@client.mediatype.get.find {|x| x['description'] == 'StackStorm'}).to_not be_nil
+      end
+
+      it 'Action configuration is set' do
+        expect(@client.action.get.find { |x| x['name'].include?('StackStorm')}).to_not be_nil
+      end
+    end
+  end
+
+  # This method wait to start and initialize Zabbix-server and Zabbix-Web
+  def try_to_login(retry_count = 0)
+    begin
+      return @client.login('admin', 'zabbix')
+    rescue => e
+      if retry_count < 60
+        # make a delay before retrying
+        sleep 1
+        return try_to_login(retry_count + 1)
+      else
+        return e
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'serverspec'
+
+set :backend, :exec
+

--- a/tools/register_st2_config_to_zabbix.py
+++ b/tools/register_st2_config_to_zabbix.py
@@ -128,18 +128,32 @@ def register_action(client, mediatype_id, options, action_id=None):
 
 
 def register_media_to_admin(client, mediatype_id, options):
-    return client.user.addmedia(**{
-        "users": [
-            {"userid": "1"},
-        ],
-        "medias": {
-            "mediatypeid": mediatype_id,
-            "sendto": options.z_sendto,
-            "active": "0",
-            "severity": "63",
-            "period": "1-7,00:00-24:00",
-        }
-    })
+    major_version = int(client.apiinfo.version()[0])
+    if major_version >= 4:
+        # This is because user.addmedia api was removed from Zabbix 4.0.
+        return client.user.update(**{
+            "userid": "1",
+            "user_medias": [{
+                "mediatypeid": mediatype_id,
+                "sendto": options.z_sendto,
+                "active": "0",
+                "severity": "63",
+                "period": "1-7,00:00-24:00",
+            }]
+        })
+    else:
+        return client.user.addmedia(**{
+            "users": [
+                {"userid": "1"},
+            ],
+            "medias": {
+                "mediatypeid": mediatype_id,
+                "sendto": options.z_sendto,
+                "active": "0",
+                "severity": "63",
+                "period": "1-7,00:00-24:00",
+            }
+        })
 
 
 def main():


### PR DESCRIPTION
This fixed #28. Furthermore, this added an integration test of running `tools/register_st2_config_to_zabbix.py` with Zabbix v3.2 and v4.0.