### PR TITLE
Added some actions which are related to deal with host object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.3.0
+
+### Added
+
+- `actions/call_api.py` - A primitive pimplemenetation of `python-script` to send a request to specified API endpoint with other specified parameters.
+- `actions/list_host_groups.yaml` - List all host_groups objects which are registered in Zabbix
+- `actions/list_host_interfaces.yaml` - List all hostinterfaces objects which are registered in Zabbix
+- `actions/list_hosts.yaml` - List all host objects which are registered in Zabbix
+- `actions/list_templates.yaml` - List all templates objects which are registered in Zabbix
+- `actions/update_host.yaml` - A primitive action to update host information
+
 ## 0.2.0
 
 ### Added

--- a/actions/call_api.py
+++ b/actions/call_api.py
@@ -1,0 +1,14 @@
+from lib.actions import ZabbixBaseAction
+from zabbix.api import ZabbixAPI
+
+
+class CallAPI(ZabbixBaseAction):
+    def run(self, api_method, token, **params):
+        # Initialize client object to connect Zabbix server
+        if token:
+            self.client = ZabbixAPI(url=self.config['zabbix']['url'])
+            self.auth = token
+        else:
+            self.connect()
+
+        return eval('self.client.%s' % api_method)(**params)

--- a/actions/list_host_groups.yaml
+++ b/actions/list_host_groups.yaml
@@ -1,0 +1,20 @@
+---
+name: list_host_groups
+pack: zabbix
+runner_type: python-script
+description: List all host_groups objects which are registered in Zabbix
+enabled: true
+entry_point: call_api.py
+parameters:
+  filter:
+    type: object
+    description: Condition to filter the result
+  token:
+    type: string
+    description: Encrypted access token to authenticate to ZabbixServer
+    default: |
+      {% if st2kv.user.zabbix.secret_token|string != '' %}{{ st2kv.user.zabbix.secret_token | decrypt_kv }}{% endif %}
+    secret: true
+  api_method:
+    default: hostgroup.get
+    immutable: true

--- a/actions/list_host_interfaces.yaml
+++ b/actions/list_host_interfaces.yaml
@@ -1,0 +1,20 @@
+---
+name: list_host_interfaces
+pack: zabbix
+runner_type: python-script
+description: List all hostinterfaces objects which are registered in Zabbix
+enabled: true
+entry_point: call_api.py
+parameters:
+  filter:
+    type: object
+    description: Condition to filter the result
+  token:
+    type: string
+    description: Encrypted access token to authenticate to ZabbixServer
+    default: |
+      {% if st2kv.user.zabbix.secret_token|string != '' %}{{ st2kv.user.zabbix.secret_token | decrypt_kv }}{% endif %}
+    secret: true
+  api_method:
+    default: hostinterface.get
+    immutable: true

--- a/actions/list_hosts.yaml
+++ b/actions/list_hosts.yaml
@@ -1,0 +1,20 @@
+---
+name: list_hosts
+pack: zabbix
+runner_type: python-script
+description: List all host objects which are registered in Zabbix
+enabled: true
+entry_point: call_api.py
+parameters:
+  filter:
+    type: object
+    description: Condition to filter the result
+  token:
+    type: string
+    description: Encrypted access token to authenticate to ZabbixServer
+    default: |
+      {% if st2kv.user.zabbix.secret_token|string != '' %}{{ st2kv.user.zabbix.secret_token | decrypt_kv }}{% endif %}
+    secret: true
+  api_method:
+    default: host.get
+    immutable: true

--- a/actions/list_templates.yaml
+++ b/actions/list_templates.yaml
@@ -1,0 +1,20 @@
+---
+name: list_templates
+pack: zabbix
+runner_type: python-script
+description: List all templates objects which are registered in Zabbix
+enabled: true
+entry_point: call_api.py
+parameters:
+  filter:
+    type: object
+    description: Condition to filter the result
+  token:
+    type: string
+    description: Encrypted access token to authenticate to ZabbixServer
+    default: |
+      {% if st2kv.user.zabbix.secret_token|string != '' %}{{ st2kv.user.zabbix.secret_token | decrypt_kv }}{% endif %}
+    secret: true
+  api_method:
+    default: template.get
+    immutable: true

--- a/actions/update_host.yaml
+++ b/actions/update_host.yaml
@@ -1,0 +1,35 @@
+---
+name: update_host
+pack: zabbix
+runner_type: python-script
+description: A primitive action to update host information
+enabled: true
+entry_point: call_api.py
+parameters:
+  hostid:
+    type: string
+    description: ID of Host to be updated
+  groups:
+    type: array
+    description: Host groups to replace the current host groups the host belongs to.
+  interfaces:
+    type: array
+    description: Host interfaces to replace the current host interfaces.
+  inventory:
+    type: object
+    description: Host inventory properties.
+  macros:
+    type: array
+    description: User macros to replace the current user macros.
+  templates:
+    type: array
+    description: Templates to replace the currently linked templates.
+  token:
+    type: string
+    description: Encrypted access token to authenticate to ZabbixServer
+    default: |
+      {% if st2kv.user.zabbix.secret_token|string != '' %}{{ st2kv.user.zabbix.secret_token | decrypt_kv }}{% endif %}
+    secret: true
+  api_method:
+    default: host.update
+    immutable: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: Zabbix Monitoring System
 keywords:
   - zabbix
   - monitoring
-version: 0.2.0
+version: 0.3.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com

--- a/tests/test_call_api.py
+++ b/tests/test_call_api.py
@@ -1,0 +1,38 @@
+import mock
+
+from zabbix_base_action_test_case import ZabbixBaseActionTestCase
+from call_api import CallAPI
+
+
+class CallAPITest(ZabbixBaseActionTestCase):
+    __test__ = True
+    action_cls = CallAPI
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_action_without_token(self, mock_conn):
+        action = self.get_action_instance(self.full_config)
+
+        # This is a mock of calling API 'hoge'
+        action.client = mock.Mock()
+        action.client.hoge.return_value = 'result'
+
+        # This checks that a method which is specified in the api_method parameter would be called
+        self.assertEqual(action.run(api_method='hoge', token=None, param='foo'), 'result')
+
+    @mock.patch('call_api.ZabbixAPI')
+    def test_run_action_with_token(self, mock_client):
+        action = self.get_action_instance(self.full_config)
+
+        # This is a mock of calling API 'hoge' to confirm that
+        # specified parameters would be passed correctly.
+        def side_effect(*args, **kwargs):
+            return (args, kwargs)
+
+        _mock_client = mock.Mock()
+        _mock_client.hoge.side_effect = side_effect
+        mock_client.return_value = _mock_client
+
+        # This checks that specified parameter and access token would be set expectedly
+        result = action.run(api_method='hoge', token='test_token', param='foo')
+        self.assertEqual(result, ((), {'param': 'foo'}))
+        self.assertEqual(action.auth, 'test_token')


### PR DESCRIPTION
## Summary

This adds some actions which are related to deal with host object via primitive implementation that sends a request to specified API endpoint with other specified parameters.

## Changes

- `actions/call_api.py` - A primitive implementation of `python-script` to send a request to specified API endpoint with other specified parameters.
- `actions/list_host_groups.yaml` - List all host_groups objects which are registered in Zabbix
- `actions/list_host_interfaces.yaml` - List all hostinterfaces objects which are registered in Zabbix
- `actions/list_hosts.yaml` - List all host objects which are registered in Zabbix
- `actions/list_templates.yaml` - List all templates objects which are registered in Zabbix
- `actions/update_host.yaml` - A primitive action to update host information
