### PR TITLE
Add explicit Python version support (including Python 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 0.3.1
+
+### Added
+
+- Explicitly specify supported Python versions
+
+### Changed
+
+- Fixups for Python 3
+
 ## 0.3.0
 
 ### Added

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -15,7 +15,7 @@
 
 from pyzabbix.api import ZabbixAPIException
 from st2common.runners.base_action import Action
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from zabbix.api import ZabbixAPI
 
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: Zabbix Monitoring System
 keywords:
   - zabbix
   - monitoring
-version: 0.3.0
+version: 0.3.1
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,3 +8,6 @@ keywords:
 version: 0.3.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
+python_versions:
+  - "2"
+  - "3"

--- a/tests/test_action_base.py
+++ b/tests/test_action_base.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from event_action_runner import EventActionRunner
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_host_delete.py
+++ b/tests/test_host_delete.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from host_delete import HostDelete
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_host_get_id.py
+++ b/tests/test_host_get_id.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from host_get_id import HostGetID
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_host_get_inventory.py
+++ b/tests/test_host_get_inventory.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from host_get_inventory import HostGetInventory
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 
 
 class HostGetInventoryTestCase(ZabbixBaseActionTestCase):

--- a/tests/test_host_get_multiple_ids.py
+++ b/tests/test_host_get_multiple_ids.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from host_get_multiple_ids import ZabbixGetMultipleHostID
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_host_get_status.py
+++ b/tests/test_host_get_status.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from host_get_status import HostGetStatus
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_host_update_status.py
+++ b/tests/test_host_update_status.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from host_update_status import HostUpdateStatus
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_maintenance_create_or_update.py
+++ b/tests/test_maintenance_create_or_update.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from maintenance_create_or_update import MaintenanceCreateOrUpdate
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_maintenance_delete.py
+++ b/tests/test_maintenance_delete.py
@@ -3,7 +3,7 @@ import mock
 from zabbix_base_action_test_case import ZabbixBaseActionTestCase
 from maintenance_delete import MaintenanceDelete
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 

--- a/tests/test_tool_register_st2_config_to_zabbix.py
+++ b/tests/test_tool_register_st2_config_to_zabbix.py
@@ -3,7 +3,7 @@ import re
 import sys
 import mock
 
-from io import BytesIO
+from six import StringIO
 from unittest import TestCase
 
 from six.moves.urllib.error import URLError
@@ -16,8 +16,8 @@ import register_st2_config_to_zabbix
 class TestRegisterMediaType(TestCase):
     def setUp(self):
         sys.argv = ['register_st2_config_to_zabbix.py']
-        self.io_stdout = BytesIO()
-        self.io_stderr = BytesIO()
+        self.io_stdout = StringIO()
+        self.io_stderr = StringIO()
         sys.stdout = self.io_stdout
         sys.stderr = self.io_stderr
 

--- a/tests/test_tool_register_st2_config_to_zabbix.py
+++ b/tests/test_tool_register_st2_config_to_zabbix.py
@@ -6,7 +6,7 @@ import mock
 from io import BytesIO
 from unittest import TestCase
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 from pyzabbix.api import ZabbixAPIException
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../tools/')

--- a/tools/register_st2_config_to_zabbix.py
+++ b/tools/register_st2_config_to_zabbix.py
@@ -5,7 +5,7 @@ import sys
 from optparse import OptionParser
 from zabbix.api import ZabbixAPI
 from pyzabbix.api import ZabbixAPIException
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 
 # This constant describes 'script' value of 'type' property in the MediaType,
 # which is specified in the Zabbix API specification.


### PR DESCRIPTION
Update the code for Python 3, and bump the pack version to `0.3.1`.