### PR TITLE
Added output and groupids parameters to list_hosts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.2
+
+- Extend `list_hosts` action to allow specifying a list of groupids (not possible in `filter`), as well as `output` to allow trimming of returned data.
+
 ## 0.3.1
 
 ### Added
@@ -31,7 +35,7 @@
 
 ### Changes
 
-- `triggers/event_handler.yaml` - `alert_message` type updated to include `array`, `object` 
+- `triggers/event_handler.yaml` - `alert_message` type updated to include `array`, `object`
   with logic in `st2_dispatch.py` to handle the difference.
 - `st2_dispatch.py` flags: `--st2-api-url` and `--st2-auth-url` no longer have default values.
   See code comments for details.
@@ -79,7 +83,7 @@
 - Changed `st2_dispatch.py` to conform to be able to communicate with up to date st2api (v2.8).
 
   **Note:** This change is backward incompatible -- the interface of `st2_dispatch.py` is changed from
-  `--st2-host` to `--st2-api-url` and `--st2-auth-url` to be able to dispach trigger through proxy.  
+  `--st2-host` to `--st2-api-url` and `--st2-auth-url` to be able to dispach trigger through proxy.
   To update from previous version to this, you should execute `register_st2_config_to_zabbix.py` command.
   This resets configuration of Zabbix for conforming to the interface of current `st2_dispatch.py`
   to dispatch `zabbix.event_handler`.
@@ -99,7 +103,7 @@
 
 - Added a new action `host_get_multiple_ids` that can retrieve 0, a single, or multiple zabbix hosts and
   return those as an array. This is for a race condition that exists when using several zabbix proxies.
-- Added a new action `host_delete_by_id` that allows a host to be deleted given the Host's ID instead of 
+- Added a new action `host_delete_by_id` that allows a host to be deleted given the Host's ID instead of
   the Host's Name
   Contributed by Brad Bishop (Encore Technologies)
 

--- a/actions/call_api.py
+++ b/actions/call_api.py
@@ -1,10 +1,22 @@
 from lib.actions import ZabbixBaseAction
 from zabbix.api import ZabbixAPI
 
+import six
+
 
 class CallAPI(ZabbixBaseAction):
     def run(self, api_method, token, **params):
         # Initialize client object to connect Zabbix server
+
+        # Python doesn't let you modify the length of a dict or list while iterating
+        iterate_params = params.copy()
+
+        # Look for Empty strings and None values, but allow False
+        # If None or '', remove it from params.
+        for key, value in six.iteritems(iterate_params):
+            if key in params and not params[key] and not params[key] is False:
+                del params[key]
+
         if token:
             self.client = ZabbixAPI(url=self.config['zabbix']['url'])
             self.auth = token

--- a/actions/call_api.py
+++ b/actions/call_api.py
@@ -1,21 +1,10 @@
 from lib.actions import ZabbixBaseAction
 from zabbix.api import ZabbixAPI
 
-import six
-
 
 class CallAPI(ZabbixBaseAction):
     def run(self, api_method, token, **params):
         # Initialize client object to connect Zabbix server
-
-        # Python doesn't let you modify the length of a dict or list while iterating
-        iterate_params = params.copy()
-
-        # Look for Empty strings and None values, but allow False
-        # If None or '', remove it from params.
-        for key, value in six.iteritems(iterate_params):
-            if key in params and not params[key] and not params[key] is False:
-                del params[key]
 
         if token:
             self.client = ZabbixAPI(url=self.config['zabbix']['url'])
@@ -23,7 +12,8 @@ class CallAPI(ZabbixBaseAction):
         else:
             self.connect()
 
-        return self._call_api_method(self.client, api_method, params)
+        return self._call_api_method(self.client, api_method,
+            {k: v for k, v in params.items() if v is not None})  # dont include param where v=None
 
     def _call_api_method(self, client, api_method, params):
         """

--- a/actions/list_hosts.yaml
+++ b/actions/list_hosts.yaml
@@ -8,7 +8,13 @@ entry_point: call_api.py
 parameters:
   filter:
     type: object
-    description: Condition to filter the result
+    description: 'Condition to filter the result. Example - {"hostid": "12345"}'
+  output:
+    description: A list of key names that limit the response data. 'hostid' is always present. Example - ["maintenance_status", "name"]
+    type: array
+  groupids:
+    description: list of groupids to limit the results to. Example - ["123", "456"]
+    type: array
   token:
     type: string
     description: Encrypted access token to authenticate to ZabbixServer

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: Zabbix Monitoring System
 keywords:
   - zabbix
   - monitoring
-version: 0.3.1
+version: 0.3.2
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:

--- a/tests/test_call_api.py
+++ b/tests/test_call_api.py
@@ -52,3 +52,24 @@ class CallAPITest(ZabbixBaseActionTestCase):
         # Send request with invalid api_method
         with self.assertRaises(RuntimeError):
             action.run(api_method='foo.hoge', token=None, param='hoge')
+
+    @mock.patch('call_api.ZabbixAPI')
+    def test_run_action_with_empty_parameters(self, mock_client):
+        action = self.get_action_instance(self.full_config)
+
+        # This is a mock of calling API 'hoge' to confirm that
+        # params with a value of None (p0) are removed prior to execution
+        # Should not remove [ '123', False, {}, [], 0 ]
+        def side_effect(*args, **kwargs):
+            return (args, kwargs)
+
+        _mock_client = mock.Mock()
+        _mock_client.hoge.side_effect = side_effect
+        mock_client.return_value = _mock_client
+
+        result = action.run(api_method='hoge', token='test_token',
+            **{'p0': None, 'p1': '123', 'p2': False, 'p3': {}, 'p4': [], 'p5': 0})
+        self.assertEqual(result, ((),
+            {'p1': '123', 'p2': False, 'p3': {}, 'p4': [], 'p5': 0}))
+        _mock_client.hoge.assert_called_with(
+            **{'p1': '123', 'p2': False, 'p3': {}, 'p4': [], 'p5': 0})


### PR DESCRIPTION
Extend the `list_hosts` action to allow specifying a list of groupids (not possible in `filter`), as well as `output` to allow trimming of returned data.

call_api.py - added a simple check for empty and None parameters. When Zabbix receives a parameter such as `output` with a value of None/Null, it will only return `hostid` instead of all the other data.