### PR TITLE
Apply change of web-nginx-mysql container's listen port

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ jobs:
       name: zabbix
       tag: ubuntu-3.2-latest
     working_directory: ~/repo
+    environment:
+      ZABBIX_API: http://localhost/
     steps:
       - integration_test_with_zabbix
 
@@ -53,6 +55,8 @@ jobs:
       name: zabbix
       tag: ubuntu-4.0-latest
     working_directory: ~/repo
+    environment:
+      ZABBIX_API: http://localhost:8080/
     steps:
       - integration_test_with_zabbix
 


### PR DESCRIPTION
Previous zabbix-web-nginx-mysql container's listen port had been
listened tcp:80 for HTTP request. But it was changed to 8080 on 29 Apr
by change of zabbix/zabbix-docker(c.f https://github.com/zabbix/zabbix-docker/commit/81be9d6ae557b5da4900bec79658344bc135f128). 
By this change, stackstorm-zabbix's integration test couldn't access to
a test zabbix server. This commit applies this listen port change to be 
able to test properly.