### PR TITLE
Use Github Actions instead of CirclecI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,114 +60,20 @@ jobs:
     steps:
       - integration_test_with_zabbix
 
-  build_and_test_python36:
+  circleci_is_disabled_job:
     docker:
-      - image: circleci/python:3.6
-      - image: rabbitmq:3
-      - image: mongo:3.4
-
-    working_directory: ~/repo
-
-    environment:
-      VIRTUALENV_DIR: "~/virtualenv"
-      # Don't install various StackStorm dependencies which are already
-      # installed by CI again in the various check scripts
-      ST2_INSTALL_DEPS: "0"
-
+      - image: cimg/base:stable
     steps:
-      - checkout
-      - restore_cache:
-          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
       - run:
-          name: Download dependencies
-          # NOTE: We don't want to use default "-e" option because this means
-          # step will fail immediately on one of the commands failures and we
-          # can't intercept the error and cause non-fatal exit in case pack
-          # doesn't declare support for Python 3
           shell: /bin/bash
-          command: |
-            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies ; ~/ci/.circle/exit_on_py3_checks $?
-      - run:
-          name: Run tests (Python 3.6)
-          # NOTE: We don't want to use default "-e" option because this means
-          # step will fail immediately on one of the commands failures and we
-          # can't intercept the error and cause non-fatal exit in case pack
-          # doesn't declare support for Python 3
-          shell: /bin/bash
-          command: ~/ci/.circle/test ; ~/ci/.circle/exit_on_py3_checks $?
-      - save_cache:
-          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
-          paths:
-            - ~/.cache/pip
-            - ~/.apt-cache
-      # NOTE: We use virtualenv files from Python 3.6 step in "deploy" job so we
-      # only persist paths from this job
-      - persist_to_workspace:
-          root: /
-          paths:
-            - home/circleci/ci
-            - home/circleci/virtualenv
-            - tmp/st2
-            - home/circleci/repo
-            - home/circleci/.gitconfig
-
-
-  deploy:
-    docker:
-      - image: circleci/python:3.6
-
-    working_directory: ~/repo
-
-    environment:
-      VIRTUALENV_DIR: "~/virtualenv"
-
-    steps:
-      - checkout
-      - restore_cache:
-          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
-      - attach_workspace:
-          at: /
-      - run:
-          name: Install dependencies
-          command: |
-            sudo apt-get update
-            sudo apt -y install gmic optipng
-            ~/ci/.circle/install_gh
-      - run:
-          # NOTE: We try to retry the script up to 5 times if it fails. The command could fail due
-          # to the race (e.g. we try to push changes to index, but index has been updated by some
-          # other pack in the mean time)
-          name: Update exchange.stackstorm.org
-          command: ~/ci/.circle/retry_on_failure.sh ~/ci/.circle/deployment
+          command: echo CircleCI disabled on StackStorm-Exchange
 
 workflows:
   version: 2
-  # Workflow which runs on each push
-  build_test_deploy_on_push:
+  integration_tests_on_push:
     jobs:
       - integration_test_with_zabbix_32
       - integration_test_with_zabbix_40
-      - build_and_test_python36
-      - deploy:
-          requires:
-            - build_and_test_python36
-            - integration_test_with_zabbix_32
-            - integration_test_with_zabbix_40
-          filters:
-            branches:
-              only: master
-  build_test_weekly:
+  circleci_is_disabled:
     jobs:
-      - build_and_test_python36
-    # Workflow which runs nightly - note we don't perform deploy job on nightly
-    # build
-    triggers:
-      # Run nightly build for the pack
-      - schedule:
-          # NOTE: We run it at 1 am UTC on every Saturday
-          cron: "0 1 * * 6"
-          filters:
-            branches:
-              only:
-                - master
+      - circleci_is_disabled_job

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  schedule:
+    # NOTE: We run this weekly at 1 am UTC on every Saturday
+    - cron:  '0 1 * * 6'
+
+jobs:
+  # This is mirrored in the release workflow.
+  build_and_test:
+    name: 'Build and Test'
+    uses: StackStorm-Exchange/ci/.github/workflows/pack-build_and_test.yaml@master
+    with:
+      enable-common-libs: true
+      #apt-cache-version: v0
+      #py-cache-version: v0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    branches:
+      # the default branch
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  # This mirrors build_and_test workflow
+  build_and_test:
+    name: 'Build and Test'
+    uses: StackStorm-Exchange/ci/.github/workflows/pack-build_and_test.yaml@master
+    with:
+      enable-common-libs: true
+      #apt-cache-version: v0
+      #py-cache-version: v0
+
+  tag_release:
+    needs: build_and_test
+    name: Tag Release
+    uses: StackStorm-Exchange/ci/.github/workflows/pack-tag_release.yaml@master


### PR DESCRIPTION
This is part of https://github.com/StackStorm/community/issues/63

This PR moves the standard Exchange CI jobs from CircleCI to GHA.

There are some additional integration test jobs that should probably also be converted, so I'm submitting this one as a PR instead of pushing to master like the rest of the packs.

Do you want to convert the other jobs or leave them where they are for now and just merge this?