### PR TITLE
Fix bug of tests for st2_dispatch script

### DIFF
--- a/tests/test_tool_st2_dispatch.py
+++ b/tests/test_tool_st2_dispatch.py
@@ -16,6 +16,7 @@ class FakeResponse(object):
 
     def __init__(self, text, status_code, reason, *args):
         self.text = text
+        self.content = text.encode('utf-8')
         self.status_code = status_code
         self.reason = reason
         if args:


### PR DESCRIPTION
st2client >= 3.5.0 refer requests.models.Response.content for decoding it.
(https://github.com/StackStorm/st2/blob/9ce3dc8ee72e1491dd567728fdb05abe55e099ed/st2client/st2client/models/core.py#L59-L63) However, FakeResponse class in test_tool_st2_dispatch doesn't have 'content' instance variable, and so tests fail due to AttributeError.

Error message:
```
st2@st2-server:/opt/stackstorm$ st2/bin/st2-run-pack-tests -x -p /opt/stackstorm/packs/zabbix/
...
TEST RESULT OUTPUT:
======================================================================
1) ERROR: test_dispatch_trigger (test_tool_st2_dispatch.TestZabbixDispatcher)
----------------------------------------------------------------------
   Traceback (most recent call last):
    /opt/stackstorm/st2/lib/python3.6/site-packages/mock/mock.py line 1346 in patched
      return func(*newargs, **newkeywargs)
    tests/test_tool_st2_dispatch.py line 66 in test_dispatch_trigger
      dispatcher = st2_dispatch.ZabbixDispatcher(options)
    tools/scripts/st2_dispatch.py line 23 in __init__
      cache_token=False)
    /opt/stackstorm/st2/lib/python3.6/site-packages/st2client/base.py line 246 in _get_auth_token
      client=client, username=username, password=password
    /opt/stackstorm/st2/lib/python3.6/site-packages/st2client/base.py line 400 in _authenticate_and_retrieve_auth_token
      instance = manager.create(instance, auth=(username, password))
    /opt/stackstorm/st2/lib/python3.6/site-packages/st2client/models/core.py line 42 in decorate
      return func(*args, **kwargs)
    /opt/stackstorm/st2/lib/python3.6/site-packages/st2client/models/core.py line 352 in create
      instance = self.resource.deserialize(parse_api_response(response))
    /opt/stackstorm/st2/lib/python3.6/site-packages/st2client/models/core.py line 60 in parse_api_response
      if isinstance(response.content, str):
   AttributeError: 'FakeResponse' object has no attribute 'content'
   -------------------- >> begin captured logging << --------------------
   st2client.base: INFO: Skipping parsing CLI config
   --------------------- >> end captured logging << ---------------------

-----------------------------------------------------------------------------
73 tests run in 2.144 seconds.
1 error (72 tests passed)
```

Add 'content' instance variable to FakeResponse class and make tests pass.