### PR TITLE
Handing over the ownership of this integration pack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 
 # This is base configuration. These owners could review the
 # whole file in this repository.
-* @userlocalhost @namachieli @StackStorm-Exchange/encoretechnologies @StackStorm-Exchange/tsc
+* @namachieli @StackStorm-Exchange/encoretechnologies @StackStorm-Exchange/tsc
 
 # CI configuration files should be reviewed by specific owners
 # who are more responsible for ensuring the quality of this pack

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - zabbix
   - monitoring
 version: 1.0.0
-author: Ian Price
-email: ianmprice@gmail.com
+author: Hiroyasu OHYAMA
+email: user.localhost2000@gmail.com
 python_versions:
   - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - zabbix
   - monitoring
 version: 1.0.0
-author: Hiroyasu OHYAMA
-email: user.localhost2000@gmail.com
+author: Ian Price
+email: ianmprice@gmail.com
 python_versions:
   - "3"


### PR DESCRIPTION
I had been enthusiast about zabbix and I created this pack. But I started to use Datadog, so I rarely use it nowadays.

There are many st2 users who want to integrate with Zabbix using this pack. So this should be maintained by someone who uses Zabbix. @namachieli is the best person as far as I know. He is not only familiar with the Zabbix but also catches up with the latest one. And he uses both st2 and its integration pack for the long time. The users must be happy if this could be maintained by this realiable engineer.