### PR TITLE
Ajust a create_host.yaml and create_host.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## 1.0.2
+
+- change create_host.py host as a string
 ## 1.0.1
 
 - change create_host.yaml host as a string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## 1.0.1
+
+- change create_host.yaml host as a string
 
 ## 1.0.0
 

--- a/actions/create_host.py
+++ b/actions/create_host.py
@@ -17,7 +17,7 @@ class CreateHost(ZabbixBaseAction):
         return [self.get_interface_config(domain=x, is_main=(x == main_if)) for x in domains]
 
     def get_interface_config_with_ipaddr(self, ipaddrs, main_if):
-        return [self.get_interface_config(ipaddr=x, is_main=(x == main_if)) for x in ipaddrs]
+        return [self.get_interface_config(ipaddrs)
 
     def set_proxy_for_host(self, proxy_name, new_hosts):
         for proxy in self.client.proxy.get(filter={'host': proxy_name}):
@@ -28,7 +28,7 @@ class CreateHost(ZabbixBaseAction):
                 'hosts': current_hosts + new_hosts,
             })
 
-    def run(self, name, groups, ipaddrs=[], domains=[], proxy_host=None, token=None, main_if=''):
+    def run(self, name, groups, ipaddrs, domains=[], proxy_host=None, token=None, main_if=''):
         # Initialize client object to connect Zabbix server
         if token:
             self.client = ZabbixAPI(url=self.config['zabbix']['url'])

--- a/actions/create_host.py
+++ b/actions/create_host.py
@@ -17,7 +17,7 @@ class CreateHost(ZabbixBaseAction):
         return [self.get_interface_config(domain=x, is_main=(x == main_if)) for x in domains]
 
     def get_interface_config_with_ipaddr(self, ipaddrs, main_if):
-        return [self.get_interface_config(ipaddrs)
+        return [self.get_interface_config(ipaddrs)]
 
     def set_proxy_for_host(self, proxy_name, new_hosts):
         for proxy in self.client.proxy.get(filter={'host': proxy_name}):

--- a/actions/create_host.yaml
+++ b/actions/create_host.yaml
@@ -15,9 +15,8 @@ parameters:
         description: HostGroups to be registered to creating host
         required: True
     ipaddrs:
-        type: array
+        type: string
         description: IP addresses of the host in which ZabbixAgent is installed
-        default: []
     domains:
         type: array
         description: Domain names of the host in which ZabbixAgent is installed

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: Zabbix Monitoring System
 keywords:
   - zabbix
   - monitoring
-version: 1.0.0
+version: 1.0.1
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: Zabbix Monitoring System
 keywords:
   - zabbix
   - monitoring
-version: 1.0.1
+version: 1.0.2
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:


### PR DESCRIPTION
When we try to create a workflow and insert this action, if you need to put a variable like <% ctx.var_name %> or  {{ ctx.var_name }} an error occured to interpret this var, thats because of a type of field ipadress expect to receive an array. after change i was able to run my workflow property 