### PR TITLE
v0.2.1 - Fix missing basic connection params for SSL Verify, timeout, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [2.0.1] - 2026-06-19
+
+### Added
+- Config params ["validate_certs", "timeout", "skip_version_check"] matching with ZabbixAPI class of zabbix_utils
+
 ## [2.0.0] - 2026-06-05
 
 **BREAKING CHANGE**: This version is not backwards compatible with previous releases. All actions have been renamed, parameters standardized, and return types changed. Existing workflows, rules, and automations that reference this pack must be refactored before upgrading.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ st2 pack config zabbix
 | `api_token` | Zabbix API token (preferred) | — | No* |
 | `username` | Zabbix username | `Admin` | No* |
 | `password` | Zabbix password | `zabbix` | No* |
+| `validate_certs` | Specifying certificate validation | `true` | No* |
+| `timeout` | Connection timeout to Zabbix API | `30` | No* |
+| `skip_version_check` |  Skip version compatibility check | `false` | No* |
 
 \* Either `api_token` OR `username`/`password` must be provided.
 

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -31,23 +31,28 @@ class ZabbixBaseAction(Action):
         if "url" not in self.config:
             raise ValueError("Zabbix url details not in the config.yaml")
         # Require either api_token or username+password
-        has_token = bool(self.config.get('api_token'))
-        has_user = bool(self.config.get('username') and
-                        self.config.get('password'))
+        has_token = bool(self.config.get("api_token"))
+        has_user = bool(self.config.get("username") and self.config.get("password"))
         if not has_token and not has_user:
-            raise ValueError("Zabbix api_token or username/password "
-                             "must be set in the config.yaml")
+            raise ValueError(
+                "Zabbix api_token or username/password "
+                "must be set in the config.yaml"
+            )
 
     def connect(self):
         try:
-            self.client = ZabbixAPI(url=self.config['url'])
-            api_token = self.config.get('api_token')
+            self.client = ZabbixAPI(
+                url=self.config["url"],
+                validate_certs=self.config["validate_certs"],
+                timeout=self.config["timeout"],
+                skip_version_check=self.config["skip_version_check"],
+            )
+            api_token = self.config.get("api_token")
             if api_token:
                 self.client.login(token=api_token)
             else:
                 self.client.login(
-                    user=self.config['username'],
-                    password=self.config['password']
+                    user=self.config["username"], password=self.config["password"]
                 )
         except APIRequestError as e:
             raise APIRequestError("Failed to authenticate with Zabbix (%s)" % str(e))
@@ -58,26 +63,29 @@ class ZabbixBaseAction(Action):
 
     def reconstruct_args_for_ack_event(self, eventid, message, will_close):
         return {
-            'eventids': eventid,
-            'message': message,
-            'action': 1 if will_close else 0,
+            "eventids": eventid,
+            "message": message,
+            "action": 1 if will_close else 0,
         }
 
     def find_host(self, host_name):
         try:
             zabbix_host = self.client.host.get(filter={"host": host_name})
         except APIRequestError as e:
-            raise APIRequestError(("There was a problem searching for the host: "
-                                   "{0}".format(e)))
+            raise APIRequestError(
+                ("There was a problem searching for the host: " "{0}".format(e))
+            )
 
         if len(zabbix_host) == 0:
             raise ValueError("Could not find any hosts named {0}".format(host_name))
         elif len(zabbix_host) >= 2:
-            raise ValueError("Multiple hosts found with the name: {0}".format(host_name))
+            raise ValueError(
+                "Multiple hosts found with the name: {0}".format(host_name)
+            )
 
         self.zabbix_host = zabbix_host[0]
 
-        return self.zabbix_host['hostid']
+        return self.zabbix_host["hostid"]
 
     def host_get_extended(self, host_ids, select_field, output_fields):
         """Retrieve extended host data by IDs with a specified select parameter.
@@ -92,41 +100,58 @@ class ZabbixBaseAction(Action):
         """
         try:
             kwargs = {
-                'hostids': host_ids,
-                select_field: 'extend',
-                'output': output_fields,
+                "hostids": host_ids,
+                select_field: "extend",
+                "output": output_fields,
             }
             return self.client.host.get(**kwargs)
         except APIRequestError as e:
             raise APIRequestError(
-                "There was a problem searching for the host: {0}".format(e))
+                "There was a problem searching for the host: {0}".format(e)
+            )
 
     def maintenance_get(self, maintenance_name):
         try:
             result = self.client.maintenance.get(filter={"name": maintenance_name})
             return result
         except APIRequestError as e:
-            raise APIRequestError(("There was a problem searching for the maintenance window: "
-                                   "{0}".format(e)))
+            raise APIRequestError(
+                (
+                    "There was a problem searching for the maintenance window: "
+                    "{0}".format(e)
+                )
+            )
 
     def maintenance_create_or_update(self, maintenance_params):
-        maintenance_result = self.maintenance_get(maintenance_params['name'])
+        maintenance_result = self.maintenance_get(maintenance_params["name"])
         if len(maintenance_result) == 0:
             try:
                 create_result = self.client.maintenance.create(**maintenance_params)
                 return create_result
             except APIRequestError as e:
-                raise APIRequestError(("There was a problem creating the "
-                                       "maintenance window: {0}".format(e)))
+                raise APIRequestError(
+                    (
+                        "There was a problem creating the "
+                        "maintenance window: {0}".format(e)
+                    )
+                )
         elif len(maintenance_result) == 1:
             try:
-                maintenance_id = maintenance_result[0]['maintenanceid']
-                update_result = self.client.maintenance.update(maintenanceid=maintenance_id,
-                                                               **maintenance_params)
+                maintenance_id = maintenance_result[0]["maintenanceid"]
+                update_result = self.client.maintenance.update(
+                    maintenanceid=maintenance_id, **maintenance_params
+                )
                 return update_result
             except APIRequestError as e:
-                raise APIRequestError(("There was a problem updating the "
-                                       "maintenance window: {0}".format(e)))
+                raise APIRequestError(
+                    (
+                        "There was a problem updating the "
+                        "maintenance window: {0}".format(e)
+                    )
+                )
         elif len(maintenance_result) >= 2:
-            raise ValueError(("There are multiple maintenance windows with the "
-                              "name: {0}").format(maintenance_params['name']))
+            raise ValueError(
+                ("There are multiple maintenance windows with the " "name: {0}").format(
+                    maintenance_params["name"]
+                )
+            )

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -17,3 +17,15 @@ api_token:
   type: string
   description: Zabbix API token (preferred over username/password)
   secret: true
+validate_certs:
+  type: boolean
+  description: Validate HTTPS certificate (honor warnings)
+  default: true
+timeout:
+  type: integer
+  description: Connection timeout to Zabbix API
+  default: 30
+skip_version_check:
+  type: boolean
+  description: Skip version compatibility check (Use at own risk)
+  default: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - monitoring
   - webhooks
   - alerts
-version: 2.0.0
+version: 2.0.1
 python_versions:
   - "3"
 author: Hiroyasu OHYAMA

--- a/tests/fixtures/token.yaml
+++ b/tests/fixtures/token.yaml
@@ -1,3 +1,6 @@
 ---
 url: http://localhost:8080
 api_token: my-test-token-12345
+validate_certs: true
+timeout: 30
+skip_version_check: false

--- a/tests/test_action_base.py
+++ b/tests/test_action_base.py
@@ -46,7 +46,12 @@ class BaseActionTestCase(ZabbixBaseActionTestCase):
         action = self.get_action_instance(self.token_config)
         action.connect()
 
-        mock_zabbix_cls.assert_called_with(url="http://localhost:8080")
+        mock_zabbix_cls.assert_called_with(
+            url="http://localhost:8080",
+            validate_certs=True,
+            timeout=30,
+            skip_version_check=False,
+        )
         mock_client.login.assert_called_once_with(token="my-test-token-12345")
 
     @mock.patch("lib.actions.ZabbixAPI")

--- a/zabbix.yaml.example
+++ b/zabbix.yaml.example
@@ -2,4 +2,8 @@
 url: http://localhost:8080
 username: Admin
 password: zabbix
+validate_certs: true
+timeout: 30
+skip_version_check: false
 # api_token: "your-api-token-here"  # preferred over username/password
+# validate_certs: false  # Use when stackstorm runners don't have CA for zabbix HTTPS cert


### PR DESCRIPTION
added Config params [validate_certs, timeout, skip_version_check] matching with ZabbixAPI class of zabbix_utils